### PR TITLE
feat: html parseをblockingするサンプル

### DIFF
--- a/src/assets/js/hello.js
+++ b/src/assets/js/hello.js
@@ -1,0 +1,3 @@
+(() => {
+  console.log("hello from defer.js");
+})();

--- a/src/assets/js/syncHeavyCalculate.js
+++ b/src/assets/js/syncHeavyCalculate.js
@@ -1,0 +1,22 @@
+(async () => {
+  const density = (x, y, z) => {
+    return Math.sqrt(x * y * Math.sin(z) ** 2);
+  }
+  // 時間のかかる同期的な計算処理
+  const calculate = (width, height, depth) => {
+   let volume = 0;
+   const deltaX = 0.1;
+   const deltaY = 0.1;
+   const deltaZ = 0.1;
+   for (let x = 0; x <= width; x += deltaX) {
+    for (let y = 0; y <= height; y += deltaY) {
+      for (let z = 0; z <= depth; z += deltaZ) {
+        volume += deltaX * deltaY * deltaZ * density(x, y, z);
+      }
+    } 
+   }
+   return volume;
+  }
+  console.log(`volume = ${calculate(100, 100, 100)}`);
+})();
+

--- a/src/controllers/blocking-html-parse.js
+++ b/src/controllers/blocking-html-parse.js
@@ -1,0 +1,81 @@
+// @ts-check
+const express = require("express");
+const router = express.Router();
+
+const syncHtml = `
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blocking HTML Parse Sample</title>
+  <script src="/assets/js/syncHeavyCalculate.js"></script>
+  <script src="/assets/js/hello.js"></script>
+</head>
+<body>
+  <h1>同期的に読み込む</h1>
+</body>
+</html>
+`;
+
+const html1 = `
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blocking HTML Parse Sample</title>
+  <script async src="/assets/js/syncHeavyCalculate.js"></script>
+`;
+
+const html2 = `
+<script defer src="/assets/js/hello.js"></script>
+</head>
+`;
+
+const html3 = `
+<body>
+  <h1>async slow execute</h1>
+</body>
+</html>
+`;
+
+router.get("/", function (req, res) {
+  res.write(`
+  <html lang="ja">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  </head>
+  <body>
+    <ol>
+      <li><a href="/blocking-html-parse/sample1">asyncの付いたscriptタグがHTMLのParseをブッキングするサンプル</a></li>
+      <li><a href="/blocking-html-parse/sample1">deferの付いたscriptがasyncのscriptの実行前にParse完了するサンプル</a></li>
+      <li><a href="/blocking-html-parse/sample3">scriptタグにオプションをつけないサンプル</a></li>
+    </ol>
+  </body>
+  </html>
+  `);
+});
+
+
+router.get("/sample1", function (req, res) {
+  res.write(html1);
+  setTimeout(() => {
+    res.write(html2);
+    res.write(html3);
+    res.end();
+  }, 300); // async-slow-execute-end.jsのダウンロード時間より十分に長い
+});
+
+router.get("/sample2", function (req, res) {
+  res.write(html1);
+  res.write(html2);
+  res.write(html3);
+  res.end();
+});
+
+router.get("/sample3", function (req, res) {
+  res.write(syncHtml);
+  res.end();
+});
+
+module.exports = router;

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -1,5 +1,6 @@
 // @ts-check
 const express = require("express");
+const blockingHtmlParse = require("./blocking-html-parse");
 const home = require("./home");
 const slow = require("./slow");
 const path = require("path");
@@ -10,6 +11,7 @@ const path = require("path");
  */
 const create = (app) => {
   app.use("/home", home);
+  app.use("/blocking-html-parse", blockingHtmlParse);
   app.use("/slow", slow);
   app.use("/assets", express.static(path.join(__dirname, "../assets/")));
 }


### PR DESCRIPTION
## 動作確認方法

```bash
git clone https://github.com/Himenon/experiment-express-server.git
# このPRにチェックアウトする
git fetch $1 pull/4/head:pr-4;
git checkout pr-4;
# インストール
yarn
# 開発サーバーを起動
yarn start
```

## 検証パターン

![js-async-defer](https://user-images.githubusercontent.com/6715229/80938738-300f7c00-8e15-11ea-95b9-4f510456ac20.png)

### Sample1

![image](https://user-images.githubusercontent.com/6715229/80934964-765cdf00-8e05-11ea-9208-c508834035b0.png)

### Sample2

![image](https://user-images.githubusercontent.com/6715229/80934968-7d83ed00-8e05-11ea-821f-eba4dc7eb4dd.png)

### Sample3

![image](https://user-images.githubusercontent.com/6715229/80934974-85439180-8e05-11ea-92c0-5ff3765dbe36.png)




その後、<http://localhost:9000/blocking-html-parse/>を開く


